### PR TITLE
Drop support for end of life Django 3.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Unreleased
+==========
+
+- Drop support for Django 3.2.
+
 0.6.0 (2024-01-13)
 ==================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,6 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: Web Environment
     Framework :: Django
-    Framework :: Django :: 3.2
     Framework :: Django :: 4.2
     Framework :: Django :: 5.0
     Intended Audience :: Developers
@@ -59,7 +58,7 @@ classifiers =
 [options]
 python_requires = >=3.8
 install_requires =
-    django>=3.2
+    django>=4.2
     djangorestframework>=3.12
     django-guardian>=2.4.0
 include_package_data = true

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,8 @@ python =
 
 [tox]
 envlist =
-        py38-django{32,42}
-        py39-django{32,42}
-        py310-django{32,42,50}
+        py39-django{42}
+        py310-django{42,50}
         py311-django{42,50}
         py312-django{42,50}
         dist,isort,lint,readme
@@ -23,7 +22,6 @@ setenv =
     PYTHONDONTWRITEBYTECODE = 1
 deps =
     coverage
-    django32: Django~=3.2
     django42: Django~=4.2
     django50: Django~=5.0
 


### PR DESCRIPTION
Drop support for Django 3.2 which is end of life